### PR TITLE
SOVL-5361: Make an option in cloud client to reflect the postprocessor start option.

### DIFF
--- a/onscale_client/api/rest_api.py
+++ b/onscale_client/api/rest_api.py
@@ -1817,6 +1817,57 @@ class RestApi(object, metaclass=Singleton):
             raise
         return response
 
+    def job_ceetron_start(self, job_id):
+        """Launches a ceetron post processor instance for this job. This incurs expense.
+
+        Returns:
+            datamodel.PostProcessorResponse object
+
+        Raises:
+            ApiError: includes HTTP error code indicating error
+
+        Examples:
+            >>> import onscale_client.api.rest_api as rest_api
+            >>> api = rest_api.RestApi(portal='prod', auth_token='AUTH_TOKEN')
+            >>> repsonse = api.job_ceetron_start(job_id='JOB_ID')
+            >>> print(response.url)
+            ''
+        """
+        if self.debug_output:
+            print("RestApi.ceetron_start:")
+        try:
+            response = self.post(
+                endpoint="/job/postprocessor/start/ceetron",
+                expected_class=datamodel.PostProcessorResponse,
+                payload=datamodel.JobPostProcessorRequest(jobId=job_id),
+            )
+        except ApiError:
+            raise
+        return response
+
+    def job_ceetron_stop(self, job_id: str):
+        """Stop a ceetron post processor instance for this job.
+
+        Raises:
+            ApiError: includes HTTP error code indicating error
+
+        Examples:
+            >>> import onscale_client.api.rest_api as rest_api
+            >>> api = rest_api.RestApi(portal='prod', auth_token='AUTH_TOKEN')
+            >>> print(api.job_ceetron_stop(job_id=JOB_ID))
+            >>> ''
+        """
+        if self.debug_output:
+            print("RestApi.paraview_stop:")
+        try:
+            response = self.post(
+                endpoint="/job/postprocessor/stop/ceetron",
+                payload=datamodel.JobRequest(jobId=job_id),
+            )
+        except ApiError:
+            raise
+        return response
+    
     def job_paraview_start(self, job_id: str, docker_tag_id: Optional[str] = None):
         """Launches a paraview server instance for this job. This incurs expense.
 

--- a/onscale_client/job.py
+++ b/onscale_client/job.py
@@ -15,7 +15,6 @@ from datetime import datetime
 from typing import List, Callable, Dict, Any, Optional
 
 import os
-
 if import_tqdm_notebook():
     from tqdm.notebook import tqdm  # type: ignore
 else:
@@ -1857,6 +1856,47 @@ class Job(object):
         else:
             print(f"{simulation_id} stop unsuccessful - {sim_stop_response.status}")
 
+    def start_ceetron(self) -> str:
+        """Start a ceetron post processor instance for this job.
+
+        Returns:
+            A string with the URL of the post-processor.
+
+        Example:
+            >>> import onscale_client as os
+            >>> client = os.Client()
+            >>> last_job = client.get_last_job()
+            >>> print(last_job.start_ceetron())
+            https://nginx.dev-hpc-us-east-1-v1-21.hpcs.dev.portal.onscale.com/ddba7cc6-5805-4a91-9b07-904e19e65695/
+        """
+        try:
+            post_processor = RestApi.job_ceetron_start(job_id = self.job_id)
+        except rest_api.ApiError as e:
+            print(f"ApiError raised - {str(e)}")
+            raise
+
+        return post_processor.url
+
+    def stop_ceetron(self):
+        """Stop an already-started ceetron post processor instance for this job.
+
+        Returns:
+            Void
+
+        Example:
+            >>> import onscale_client as os
+            >>> client = os.Client()
+            >>> last_job = client.get_last_job()
+            >>> last_job.stop_ceetron()
+        """
+        try:
+            post_processor = RestApi.job_ceetron_stop(job_id = self.job_id)
+        except rest_api.ApiError as e:
+            print(f"ApiError raised - {str(e)}")
+            raise
+
+        return
+    
     def tag(self, new_tag: str, tag_type: str = "ProjectTag"):
         """Applies this tag to the job
 


### PR DESCRIPTION
There are new methods in the `job` class: `start_ceetron()` and `stop_ceetron()`. The first one returns a string with the URL. The second returns `void`.

 1. The call to the REST API `/job/postprocessor/start/ceetron` also returns a `secret`. If this is needed, then `job.start_ceetron()` should return an object instead of a string.
 2. The call to `/job/postprocessor/stop/ceetron` sometimes returns a 500 error, maybe because when testing I was trying to stop the instance before it was even started. This should be further tested.