### PR TITLE
enable direct mapdl submit

### DIFF
--- a/onscale_client/api/datamodel.py
+++ b/onscale_client/api/datamodel.py
@@ -341,6 +341,7 @@ class Operation(Enum):
     ESTIMATE = 'ESTIMATE'
     REVIEW = 'REVIEW'
     BUILD = 'BUILD'
+    MAPDL_MPI = 'MAPDL_MPI'
 
 
 class Preprocessor(Enum):

--- a/onscale_client/client.py
+++ b/onscale_client/client.py
@@ -1246,6 +1246,7 @@ error in user_name or password or client_pools - {ce}"
             elif (
                 input_obj.endswith(".flxinp")
                 or input_obj.endswith(".json")
+                or input_obj.endswith(".pb")
                 or input_obj.find(".") == -1
             ):
                 return self.submit_solver_input_file(


### PR DESCRIPTION
not sure why we're so picky on the file extensions, but we can fix that when we implement this in PyCloudSolve